### PR TITLE
Make smaller docker image using multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM python:3
+FROM python:3-alpine as build
 
-RUN mkdir /src
-COPY ./requirements.txt /src
-RUN pip install -r /src/requirements.txt
-COPY ./collector.py /src
+WORKDIR /install
+
+COPY ./requirements.txt /requirements.txt
+RUN pip install --prefix=/install -r /requirements.txt
+
+FROM python:3-alpine
 
 WORKDIR /src
 ENV PYTHONPATH '/src/'
+
+COPY --from=build /install /usr/local
+COPY ./collector.py /src
 
 EXPOSE 80/TCP
 


### PR DESCRIPTION
Make docker image smaller

```
docker build -t petrjurasek/docker-hub-rate-limit-exporter .
Sending build context to Docker daemon  1.632MB
Step 1/11 : FROM python:3-alpine as build
 ---> bcab265f7997
Step 2/11 : WORKDIR /install
 ---> Using cache
 ---> 89841d543429
Step 3/11 : COPY ./requirements.txt /requirements.txt
 ---> Using cache
 ---> f11e405f8b7f
Step 4/11 : RUN pip install --prefix=/install -r /requirements.txt
 ---> Using cache
 ---> 969a9e782b6b
Step 5/11 : FROM python:3-alpine
 ---> bcab265f7997
Step 6/11 : WORKDIR /src
 ---> Using cache
 ---> 3beb98e81b4b
Step 7/11 : ENV PYTHONPATH '/src/'
 ---> Using cache
 ---> 14a599d0a5a7
Step 8/11 : COPY --from=build /install /usr/local
 ---> Using cache
 ---> 06518f027d2e
Step 9/11 : COPY ./collector.py /src
 ---> Using cache
 ---> 642997fc642e
Step 10/11 : EXPOSE 80/TCP
 ---> Using cache
 ---> 42b51bc779d4
Step 11/11 : ENTRYPOINT python /src/collector.py
 ---> Using cache
 ---> 46aaa0825397
Successfully built 46aaa0825397
Successfully tagged petrjurasek/docker-hub-rate-limit-exporter:latest
```

```
docker images | grep docker-hub-rate-limit-exporter
petrjurasek/docker-hub-rate-limit-exporter   latest              46aaa0825397        4 minutes ago       49MB
viadee/docker-hub-rate-limit-exporter        version-1.1         4f3514c373e1        28 hours ago        895MB
```
