### PR TITLE
Add ServiceMonitor to HelmChart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -27,5 +27,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-    {{- include "docker-hub-rate-limit-exporter.labels" . | nindent 6 }}
+      {{- include "docker-hub-rate-limit-exporter.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "docker-hub-rate-limit-exporter.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "docker-hub-rate-limit-exporter.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+
+spec:
+  endpoints:
+    - port: http
+      path: /
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+    {{- include "docker-hub-rate-limit-exporter.labels" . | nindent 6 }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceMonitor:
+    enabled: true
+    additionalLabels: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+
 serviceAccount:
     # Specifies whether a service account should be created
     create: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,7 +19,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceMonitor:
-    enabled: true
+    enabled: false
     additionalLabels: {}
     # namespace: monitoring
     # interval: 30s


### PR DESCRIPTION
The ServiceMonitor should be part of the helm chart. I am not sure whether it should be enabled by default, but I am going with yes.