### PR TITLE
Fix incorrect protocol on EXPOSE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ENV PYTHONPATH '/src/'
 COPY --from=build /install /usr/local
 COPY ./collector.py /src
 
-EXPOSE 80/TCP
+EXPOSE 80/tcp
 
 ENTRYPOINT ["python", "/src/collector.py"]


### PR DESCRIPTION
I know this is really minor, but in our environment, the Dockerfile threw an error that `TCP` was an invalid protocol, so I changed it to `tcp` instead.

REF: https://docs.docker.com/engine/reference/builder/#expose