### PR TITLE
Stabilize docker readings behavior 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 prometheus_client
+pyjwt


### PR DESCRIPTION
Sometimes docker doesn't return any values in the headers. The header just contains the timespan, but not the actual value. In Issues #15  and #6 the behavior is visible and should be effectively mitigated by this PR. 
With this pull request we do the following:
- decode the JWT token and extract the limit contained in there
- store the current value to re-use it on the next run when it occurs that the header returned from docker is not complete