### PR TITLE
Bind ipv6

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -119,7 +119,7 @@ if __name__ == '__main__':
     if not port:
         port = 80
 
-    start_http_server(int(port))
+    start_http_server(int(port),addr='::')
 
     verbose = os.environ.get('DOCKERHUB_EXPORTER_VERBOSE')
 
@@ -136,4 +136,3 @@ if __name__ == '__main__':
     while True:
         time.sleep(10)
         dhc.collect()
-


### PR DESCRIPTION
In k8s IPv6 only clusters, we cannot run `docker-hub-rate-limit-exporter`

* add `addr='::'` in order to bind both ipv4 and ipv6