### PR TITLE
Sync values file and template. Add error handling

### DIFF
--- a/charts/docker-hub-rate-limit-exporter-chart/templates/daemonset.yaml
+++ b/charts/docker-hub-rate-limit-exporter-chart/templates/daemonset.yaml
@@ -9,9 +9,9 @@ spec:
   selector:
     matchLabels:
       {{- include "docker-hub-rate-limit-exporter.selectorLabels" . | nindent 6 }}
-  {{- if .Values.daemonset.updateStrategy }}
+  {{- if .Values.updateStrategy }}
   updateStrategy:
-{{ toYaml .Values.daemonset.updateStrategy | indent 4 }}
+{{ toYaml .Values.updateStrategy | indent 4 }}
   {{- end }}
   template:
     metadata:
@@ -20,8 +20,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- if .Values.daemonset.podAnnotations }}
-        {{- toYaml .Values.daemonset.podAnnotations | nindent 8 }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
@@ -81,17 +81,17 @@ spec:
                 configMapKeyRef:
                   name: {{ include "docker-hub-rate-limit-exporter.fullname" . }}-configmap
                   key: exporter-port
-      {{- if .Values.daemonset.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.daemonset.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.daemonset.affinity | indent 8 }}
+{{ toYaml .Values.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.daemonset.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.daemonset.tolerations | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}

--- a/charts/docker-hub-rate-limit-exporter-chart/templates/deployment.yaml
+++ b/charts/docker-hub-rate-limit-exporter-chart/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "docker-hub-rate-limit-exporter.labels" . | nindent 4 }}
 spec:
-  replicas: {{ hasKey .Values.deployment "replicaCount" | ternary .Values.deployment.replicaCount 1 }}
+  replicas: {{ hasKey .Values "replicaCount" | ternary .Values.replicaCount 1 }}
   selector:
     matchLabels:
       {{- include "docker-hub-rate-limit-exporter.selectorLabels" . | nindent 6 }}
@@ -18,8 +18,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- if .Values.deployment.podAnnotations }}
-        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
@@ -79,17 +79,17 @@ spec:
                 configMapKeyRef:
                   name: {{ include "docker-hub-rate-limit-exporter.fullname" . }}-configmap
                   key: exporter-port
-      {{- if .Values.deployment.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.deployment.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.deployment.affinity | indent 8 }}
+{{ toYaml .Values.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.deployment.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.deployment.tolerations | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
 
 {{- end }}

--- a/charts/docker-hub-rate-limit-exporter-chart/values.schema.json
+++ b/charts/docker-hub-rate-limit-exporter-chart/values.schema.json
@@ -1,0 +1,246 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "affinity": {
+            "properties": {},
+            "type": "object"
+        },
+        "config": {
+            "properties": {
+                "dockerhub": {
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "verbosity": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "daemonset": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "deployment": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "hostNetwork": {
+            "type": "boolean"
+        },
+        "hostPID": {
+            "type": "boolean"
+        },
+        "image": {
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": { "type": "string" }
+                }
+            }
+        },
+        "livenessProbeTimeoutSeconds": {
+            "type": "integer"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "properties": {},
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {}
+            }
+        },
+        "podSecurityContext": {
+            "properties": {},
+            "type": "object"
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "readinessProbeTimeoutSeconds": {
+            "type": "integer"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "properties": {
+                "limits": {
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "requests": {
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "securityContext": {
+            "properties": {},
+            "type": "object"
+        },
+        "service": {
+            "properties": {
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "nodePort": {
+                    "type": "integer"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "portName": {
+                    "type": "string"
+                },
+                "targetPort": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "serviceAccount": {
+            "properties": {
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" }
+                        }
+                    }
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "serviceMonitor": {
+            "properties": {
+                "additionalLabels": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "bearerTokenFile": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "jobLabel": {
+                    "type": "string"
+                },
+                "metricRelabelings": {
+                    "type": "array"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "proxyUrl": {
+                    "type": "string"
+                },
+                "relabelings": {
+                    "type": "array"
+                },
+                "scheme": {
+                    "type": "string"
+                },
+                "scrapeTimeout": {
+                    "type": "string"
+                },
+                "selectorOverride": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "tlsConfig": {
+                    "properties": {},
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "tolerations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {}
+            }
+        },
+        "updateStrategy": {
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/charts/docker-hub-rate-limit-exporter-chart/values.yaml
+++ b/charts/docker-hub-rate-limit-exporter-chart/values.yaml
@@ -32,7 +32,7 @@ serviceMonitor:
     jobLabel: ""
 
     scheme: http
-    bearerTokenFile:
+    bearerTokenFile: ""
     tlsConfig: {}
 
     ## proxyUrl: URL of a proxy that should be used for scraping.
@@ -73,9 +73,9 @@ service:
     type: ClusterIP
     port: 9100
     targetPort: 9100
-    nodePort:
     portName: metrics
     annotations: {}
+    # nodePort: 
 
 livenessProbeTimeoutSeconds: 5
 
@@ -96,3 +96,14 @@ tolerations: []
 priorityClassName: ""
 
 affinity: {}
+
+podAnnotations: [] 
+
+# Only relevant for `deployment.enabled: true`
+replicaCount: 1
+
+# Only relevant for `daemonset.enabled: true`
+updateStrategy: ""
+
+# hostNetwork: false
+# hostPID: false


### PR DESCRIPTION
This PR syncs the `values.yaml` to the variables used inside the templates by adding missing defaults and moving tolerations, ... back to top level as described in #27.

Additionally added a jsonschema file for validation of supplied values.

The error message would look like this (example from `helm lint` with an "old-style" `values.yaml`)

```
==> Linting chart
[ERROR] values.yaml: - daemonset: Additional property tolerations is not allowed

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
docker-hub-rate-limit-exporter:
- daemonset: Additional property tolerations is not allowed


Error: 1 chart(s) linted, 1 chart(s) failed
```

According to helm/helm#12842 custom error messages are not yet possible.

Notes:

* I did not add very detailed properties for complex objects like `securityContext` in order to keep maintainability. 
* I commented out `service.nodePort`, `hostNetwork` and `hostPID` as these variables do not have a default value and the linter would have flagged them when left empty.
* The schema file was generated by [losisin/helm-values-schema-json](/losisin/helm-values-schema-json)